### PR TITLE
Fix infinite loop in useEffect by removing dependencies and adding explanatory comments.

### DIFF
--- a/src/pages/previous_games/PreviousGamesPage.tsx
+++ b/src/pages/previous_games/PreviousGamesPage.tsx
@@ -19,7 +19,9 @@ function PreviousGamesPage() {
 
   useEffect(() => {
     void getPreviousGamesList();
-  }, [getPreviousGamesList]);
+    // DO NOT add getPreviousGamesList to the dependency array, because it will cause an infinite loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   function renderPreviousGames() {
     if (previousGamesList?.length === 0) {


### PR DESCRIPTION
This pull request makes a small change to the `PreviousGamesPage` component to address a potential infinite loop issue in the `useEffect` hook. The dependency array for the hook has been changed to an empty array, and a comment was added to clarify the reasoning.

* Prevented an infinite loop in the `useEffect` hook by changing the dependency array to empty, and added a clarifying comment and eslint directive in `src/pages/previous_games/PreviousGamesPage.tsx`.